### PR TITLE
optimize(udp): use address type to filter wrong password early

### DIFF
--- a/cipher/cipher.go
+++ b/cipher/cipher.go
@@ -6,24 +6,26 @@ import (
 	"crypto/md5"
 	"crypto/sha1"
 	"github.com/Qv2ray/mmp-go/common/pool"
+	"github.com/studentmain/smaead"
 	"golang.org/x/crypto/chacha20poly1305"
 	"golang.org/x/crypto/hkdf"
 	"io"
 )
 
 var CiphersConf = map[string]CipherConf{
-	"chacha20-ietf-poly1305": {KeyLen: 32, SaltLen: 32, NonceLen: 12, TagLen: 16, NewCipher: chacha20poly1305.New},
-	"chacha20-poly1305":      {KeyLen: 32, SaltLen: 32, NonceLen: 12, TagLen: 16, NewCipher: chacha20poly1305.New},
-	"aes-256-gcm":            {KeyLen: 32, SaltLen: 32, NonceLen: 12, TagLen: 16, NewCipher: NewGcm},
-	"aes-128-gcm":            {KeyLen: 16, SaltLen: 16, NonceLen: 12, TagLen: 16, NewCipher: NewGcm},
+	"chacha20-ietf-poly1305": {KeyLen: 32, SaltLen: 32, NonceLen: 12, TagLen: 16, NewCipher: chacha20poly1305.New, NewPartialCipher: NewPC20P1305},
+	"chacha20-poly1305":      {KeyLen: 32, SaltLen: 32, NonceLen: 12, TagLen: 16, NewCipher: chacha20poly1305.New, NewPartialCipher: NewPC20P1305},
+	"aes-256-gcm":            {KeyLen: 32, SaltLen: 32, NonceLen: 12, TagLen: 16, NewCipher: NewGcm, NewPartialCipher: NewPGcm},
+	"aes-128-gcm":            {KeyLen: 16, SaltLen: 16, NonceLen: 12, TagLen: 16, NewCipher: NewGcm, NewPartialCipher: NewPGcm},
 }
 
 type CipherConf struct {
-	KeyLen    int
-	SaltLen   int
-	NonceLen  int
-	TagLen    int
-	NewCipher func(key []byte) (cipher.AEAD, error)
+	KeyLen           int
+	SaltLen          int
+	NonceLen         int
+	TagLen           int
+	NewCipher        func(key []byte) (cipher.AEAD, error)
+	NewPartialCipher func(key []byte) (smaead.PartialAEAD, error)
 }
 
 const MaxNonceSize = 12
@@ -48,6 +50,26 @@ func (conf *CipherConf) Verify(buf []byte, masterKey []byte, salt []byte, cipher
 		return nil, false
 	}
 	return buf[:len(cipherText)-ciph.Overhead()], true
+}
+
+func (conf *CipherConf) UnsafeVerifyATyp(masterKey []byte, salt []byte, cipherText []byte) bool {
+	subKey := pool.Get(conf.KeyLen)
+	defer pool.Put(subKey)
+	kdf := hkdf.New(
+		sha1.New,
+		masterKey,
+		salt,
+		ReusedInfo,
+	)
+	io.ReadFull(kdf, subKey)
+
+	ciph, _ := conf.NewPartialCipher(subKey)
+	plain := ciph.OpenWithoutCheck(nil, ZeroNonce[:conf.NonceLen], cipherText[:1])
+	atyp := plain[0]
+	if atyp == 1 || atyp == 3 || atyp == 4 {
+		return true
+	}
+	return false
 }
 
 func MD5Sum(d []byte) []byte {
@@ -82,4 +104,16 @@ func NewGcm(key []byte) (cipher.AEAD, error) {
 		return nil, err
 	}
 	return cipher.NewGCM(block)
+}
+
+func NewPC20P1305(key []byte) (smaead.PartialAEAD, error) {
+	return smaead.NewPartialChacha20Poly1305(key)
+}
+
+func NewPGcm(key []byte) (smaead.PartialAEAD, error) {
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	return smaead.NewPartialGCM(block)
 }

--- a/dispatcher/tcp/tcp.go
+++ b/dispatcher/tcp/tcp.go
@@ -146,5 +146,5 @@ func probe(buf []byte, data []byte, server *config.Server) ([]byte, bool) {
 	salt := data[:conf.SaltLen]
 	cipherText := data[conf.SaltLen : conf.SaltLen+2+conf.TagLen]
 
-	return conf.Verify(buf, server.MasterKey, salt, cipherText)
+	return conf.Verify(buf, server.MasterKey, salt, cipherText, nil)
 }

--- a/dispatcher/tcp/tcp_test.go
+++ b/dispatcher/tcp/tcp_test.go
@@ -1,0 +1,31 @@
+package tcp
+
+import (
+	"github.com/Qv2ray/mmp-go/config"
+	"math/rand"
+	"net"
+	"testing"
+)
+
+func BenchmarkAuth(b *testing.B) {
+	const nServers = 100
+	g := new(config.Group)
+	for i := 0; i < nServers; i++ {
+		var b [10]byte
+		rand.Read(b[:])
+		g.Servers = append(g.Servers, config.Server{
+			Target:   "127.0.0.1:1080",
+			Method:   "chacha20-ietf-poly1305",
+			Password: string(b[:]),
+		})
+	}
+	g.BuildMasterKeys()
+	g.BuildUserContextPool(10)
+	var buf [50]byte
+	var data [50]byte
+	var d = New(g)
+	addr, _ := net.ResolveIPAddr("tcp", "127.0.0.1:50000")
+	for i := 0; i < b.N; i++ {
+		d.Auth(buf[:], data[:], g.UserContextPool.GetOrInsert(addr, g.Servers))
+	}
+}

--- a/dispatcher/tcp/tcp_test.go
+++ b/dispatcher/tcp/tcp_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func BenchmarkAuth(b *testing.B) {
+func BenchmarkDispatcher_Auth(b *testing.B) {
 	const nServers = 100
 	g := new(config.Group)
 	for i := 0; i < nServers; i++ {

--- a/dispatcher/udp/udp.go
+++ b/dispatcher/udp/udp.go
@@ -207,7 +207,7 @@ func probe(buf []byte, data []byte, server *config.Server) ([]byte, bool) {
 	}
 	salt := data[:conf.SaltLen]
 	cipherText := data[conf.SaltLen:]
-	if !conf.UnsafeVerifyATyp(server.MasterKey, salt, cipherText) {
+	if !conf.UnsafeVerifyATyp(buf, server.MasterKey, salt, cipherText) {
 		return nil, false
 	}
 	return conf.Verify(buf, server.MasterKey, salt, cipherText)

--- a/dispatcher/udp/udp.go
+++ b/dispatcher/udp/udp.go
@@ -207,8 +207,11 @@ func probe(buf []byte, data []byte, server *config.Server) ([]byte, bool) {
 	}
 	salt := data[:conf.SaltLen]
 	cipherText := data[conf.SaltLen:]
-	if !conf.UnsafeVerifyATyp(buf, server.MasterKey, salt, cipherText) {
+
+	subKey := pool.Get(conf.KeyLen)[:0]
+	defer pool.Put(subKey)
+	if !conf.UnsafeVerifyATyp(buf, server.MasterKey, salt, cipherText, &subKey) {
 		return nil, false
 	}
-	return conf.Verify(buf, server.MasterKey, salt, cipherText)
+	return conf.Verify(buf, server.MasterKey, salt, cipherText, &subKey)
 }

--- a/dispatcher/udp/udp.go
+++ b/dispatcher/udp/udp.go
@@ -207,6 +207,8 @@ func probe(buf []byte, data []byte, server *config.Server) ([]byte, bool) {
 	}
 	salt := data[:conf.SaltLen]
 	cipherText := data[conf.SaltLen:]
-
+	if !conf.UnsafeVerifyATyp(server.MasterKey, salt, cipherText) {
+		return nil, false
+	}
 	return conf.Verify(buf, server.MasterKey, salt, cipherText)
 }

--- a/dispatcher/udp/udp_test.go
+++ b/dispatcher/udp/udp_test.go
@@ -1,13 +1,18 @@
 package udp
 
 import (
+	"bytes"
+	"crypto/sha1"
+	"encoding/binary"
+	"github.com/Qv2ray/mmp-go/cipher"
 	"github.com/Qv2ray/mmp-go/config"
+	"golang.org/x/crypto/hkdf"
 	"math/rand"
 	"net"
 	"testing"
 )
 
-func BenchmarkAuth(b *testing.B) {
+func BenchmarkDispatcher_Auth(b *testing.B) {
 	const nServers = 100
 	g := new(config.Group)
 	for i := 0; i < nServers; i++ {
@@ -27,5 +32,95 @@ func BenchmarkAuth(b *testing.B) {
 	addr, _ := net.ResolveIPAddr("udp", "127.0.0.1:50000")
 	for i := 0; i < b.N; i++ {
 		d.Auth(buf[:], data[:], g.UserContextPool.GetOrInsert(addr, g.Servers))
+	}
+}
+
+// TestDispatcher_Auth just test if single server auth works
+func TestDispatcher_Auth(t *testing.T) {
+	const testSize = 500000
+	const method = "chacha20-ietf-poly1305"
+	const password = "password"
+
+	g := new(config.Group)
+	g.Servers = []config.Server{{
+		Target:   "127.0.0.1:1080",
+		Method:   method,
+		Password: password,
+	}}
+	g.BuildMasterKeys()
+	g.BuildUserContextPool(10)
+	var d = New(g)
+
+	type test struct {
+		data     []byte
+		positive bool
+	}
+
+	var tests []test
+	var salt [32]byte
+	for i := 0; i < testSize; i++ {
+		rand.Read(salt[:])
+		atyp := rand.Intn(6) //0 2 5 is invalid atyp
+		var addr []byte
+		var tt test
+		switch atyp {
+		case cipher.ATypeIPv4:
+			addr = make([]byte, 1+4+2)
+			copy(addr[1:], net.IPv4(byte(rand.Intn(255)), byte(rand.Intn(255)), byte(rand.Intn(255)), byte(rand.Intn(255))).To4())
+			binary.BigEndian.PutUint16(addr[1+4:], uint16(rand.Intn(65536)))
+		case cipher.ATypeIpv6:
+			addr = make([]byte, 1+16+2)
+			// v4 in v6; fake v6
+			copy(addr[1:], net.IPv4(byte(rand.Intn(255)), byte(rand.Intn(255)), byte(rand.Intn(255)), byte(rand.Intn(255))))
+			binary.BigEndian.PutUint16(addr[1+16:], uint16(rand.Intn(65536)))
+		case cipher.ATypeDomain:
+			dm := "apple.com"
+			addr = make([]byte, 1+1+len(dm)+2)
+			addr[1] = byte(len(dm))
+			copy(addr[1+1:], dm)
+			binary.BigEndian.PutUint16(addr[1+1+len(dm):], uint16(rand.Intn(65536)))
+		default:
+			addr = make([]byte, 1+6+rand.Intn(16))
+		loop:
+			for {
+				switch addr[0] {
+				case cipher.ATypeIPv4, cipher.ATypeDomain, cipher.ATypeIpv6:
+					rand.Read(addr)
+				default:
+					break loop
+				}
+			}
+		}
+		var payload = make([]byte, 16+rand.Intn(512))
+		rand.Read(payload)
+
+		switch atyp {
+		case cipher.ATypeIPv4, cipher.ATypeDomain, cipher.ATypeIpv6:
+			tt.positive = true
+			addr[0] = byte(atyp)
+
+			conf := cipher.CiphersConf[method]
+			kdf := hkdf.New(sha1.New, g.Servers[0].MasterKey, salt[:], cipher.ReusedInfo)
+			sk := make([]byte, conf.KeyLen)
+			kdf.Read(sk)
+			aead, _ := conf.NewCipher(sk)
+			dataLen := len(addr) + len(payload) + aead.Overhead()
+			data := make([]byte, dataLen)
+			aead.Seal(data[:0], cipher.ZeroNonce[:aead.NonceSize()], bytes.Join([][]byte{addr, payload}, nil), nil)
+			tt.data = bytes.Join([][]byte{salt[:], data[:dataLen]}, nil)
+		default:
+			tt.data = bytes.Join([][]byte{salt[:], addr, payload}, nil)
+		}
+		tests = append(tests, tt)
+	}
+
+	var buf [65535]byte
+	addr, _ := net.ResolveIPAddr("udp", "127.0.0.1:50000")
+	for _, test := range tests {
+		hit, _ := d.Auth(buf[:], test.data, g.UserContextPool.GetOrInsert(addr, g.Servers))
+		valid := hit != nil
+		if valid != test.positive {
+			t.Fail()
+		}
 	}
 }

--- a/dispatcher/udp/udp_test.go
+++ b/dispatcher/udp/udp_test.go
@@ -1,0 +1,31 @@
+package udp
+
+import (
+	"github.com/Qv2ray/mmp-go/config"
+	"math/rand"
+	"net"
+	"testing"
+)
+
+func BenchmarkAuth(b *testing.B) {
+	const nServers = 100
+	g := new(config.Group)
+	for i := 0; i < nServers; i++ {
+		var b [10]byte
+		rand.Read(b[:])
+		g.Servers = append(g.Servers, config.Server{
+			Target:   "127.0.0.1:1080",
+			Method:   "chacha20-ietf-poly1305",
+			Password: string(b[:]),
+		})
+	}
+	g.BuildMasterKeys()
+	g.BuildUserContextPool(10)
+	var buf [65535]byte
+	var data [65535]byte
+	var d = New(g)
+	addr, _ := net.ResolveIPAddr("udp", "127.0.0.1:50000")
+	for i := 0; i < b.N; i++ {
+		d.Auth(buf[:], data[:], g.UserContextPool.GetOrInsert(addr, g.Servers))
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/Qv2ray/mmp-go
 go 1.15
 
 require (
-	golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392
+	github.com/studentmain/smaead v0.0.0-20201230222852-75aa2464875d
+	golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad
 	golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3
 )

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
+github.com/studentmain/smaead v0.0.0-20201230222852-75aa2464875d h1:8cJZoaJdg0EFv+7ryIWRTnviorsmmHT5H06jx6621CI=
+github.com/studentmain/smaead v0.0.0-20201230222852-75aa2464875d/go.mod h1:1jZXK8G4HFsNzvB6tVf8eQ4lKPb9ccsXoZxDah0Yjb0=
 golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
-golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392 h1:xYJJ3S178yv++9zXV/hnr29plCAGO9vAFG9dorqaFQc=
-golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
+golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad h1:DN0cp81fZ3njFcrLCytUHRSUkqBjfTo4Tx9RJTWs0EY=
+golang.org/x/crypto v0.0.0-20201221181555-eec23a3978ad/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3 h1:0GoQqolDA55aaLxZyTzK/Y2ePZzZTUrRacwib7cNsYQ=
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=


### PR DESCRIPTION
AEAD data can be partially decrypted *without check tag*, so we can see address type without decrypt full packet. Then we can use it to filter out 253/256 wrong situation.

Note: Not tested

Note: Partially decrypt AEAD cipher text is not suggested, we lost integrity check when doing so.